### PR TITLE
fix _longjmp gcc error

### DIFF
--- a/hexdump.c
+++ b/hexdump.c
@@ -1302,7 +1302,7 @@ struct hexdump *hxd_open(int *error) {
 
 	hxd_init(X);
 
-	return X;	
+	return X;
 syerr:
 	*error = errno;
 
@@ -1335,7 +1335,7 @@ void hxd_reset(struct hexdump *X) {
 } /* hxd_reset() */
 
 
-int hxd_compile(struct hexdump *X, const char *_fmt, int flags) {
+int hxd_compile(struct hexdump *X, const char * volatile _fmt, int flags) {
 	const unsigned char *fmt = (const unsigned char *)_fmt;
 	unsigned char *tmp;
 	int error;
@@ -1368,7 +1368,7 @@ int hxd_compile(struct hexdump *X, const char *_fmt, int flags) {
 			if ('/' == skipws(&fmt, 0)) {
 				fmt++;
 				limit = getint(&fmt);
-	
+
 				if (*fmt == '?') {
 					flags |= HXD_NOPADDING;
 					fmt++;
@@ -1416,7 +1416,7 @@ const char *hxd_help(struct hexdump *X) {
 } /* hxd_help() */
 
 
-int hxd_write(struct hexdump *X, const void *src, size_t len) {
+int hxd_write(struct hexdump *X, const void * volatile src, size_t len) {
 	const unsigned char *p, *pe;
 	size_t n;
 	int error;

--- a/hexdump.h
+++ b/hexdump.h
@@ -110,13 +110,13 @@ void hxd_reset(struct hexdump *);
 #define HXD_LITTLE_ENDIAN  0x02
 #define HXD_NOPADDING      0x04
 
-hxd_error_t hxd_compile(struct hexdump *, const char *, int);
+hxd_error_t hxd_compile(struct hexdump *,  const char * volatile , int);
 
 const char *hxd_help(struct hexdump *);
 
 size_t hxd_blocksize(struct hexdump *);
 
-hxd_error_t hxd_write(struct hexdump *, const void *, size_t);
+hxd_error_t hxd_write(struct hexdump *, const void * volatile , size_t);
 
 hxd_error_t hxd_flush(struct hexdump *);
 
@@ -149,7 +149,7 @@ size_t hxd_read(struct hexdump *, void *, size_t);
  *
  *   local hexdump = require"hexdump"
  *
- *   hexdump.NATIVE 
+ *   hexdump.NATIVE
  *   hexdump.NETWORK
  *   hexdump.BIG_ENDIAN
  *   hexdump.LITTLE_ENDIAN
@@ -160,7 +160,7 @@ size_t hxd_read(struct hexdump *, void *, size_t);
  *     Bitwise flag which disables padding; instead, formatting units are
  *     skipped entirely when the block buffer is too short.
  *
- *   hexdump.b 
+ *   hexdump.b
  *   hexdump.c
  *   hexdump.C
  *   hexdump.d
@@ -206,7 +206,7 @@ size_t hxd_read(struct hexdump *, void *, size_t);
  *
  *   :read()
  *     Drains and returns the output buffer as a string.
- * 
+ *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int luaopen_hexdump(/* pointer to lua_State */);


### PR DESCRIPTION
suggested fix for [issue 1](https://github.com/wahern/hexdump/issues/1). 
Setting the pointer to volatile fixes the issue.
